### PR TITLE
feat: Testing workflow summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ORGANIZATION: <YOUR_ORGANIZATION_GOES_HERE>
+
+      - name: Post evergreen job summary
+        run: cat summmary.md >> $GITHUB_STEP_SUMMARY
 ```
 
 #### Advanced
@@ -251,7 +254,7 @@ jobs:
           CREATED_AFTER_DATE: ${{ env.one_week_ago }}
       
       - name: Post evergreen job summary
-        run: cat summmary.md >> GITHUB_STEP_SUMMARY
+        run: cat summmary.md >> $GITHUB_STEP_SUMMARY
 ```
 
 #### Using GitHub app
@@ -286,7 +289,7 @@ jobs:
           GROUP_DEPENDENCIES: True
 
       - name: Post evergreen job summary
-        run: cat summmary.md >> GITHUB_STEP_SUMMARY
+        run: cat summmary.md >> $GITHUB_STEP_SUMMARY
 ```
 
 ## Local usage without Docker

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ jobs:
           ORGANIZATION: <YOUR_ORGANIZATION_GOES_HERE>
 
       - name: Post evergreen job summary
-        run: cat summmary.md >> $GITHUB_STEP_SUMMARY
+        run: cat summary.md >> $GITHUB_STEP_SUMMARY
 ```
 
 #### Advanced
@@ -254,7 +254,7 @@ jobs:
           CREATED_AFTER_DATE: ${{ env.one_week_ago }}
       
       - name: Post evergreen job summary
-        run: cat summmary.md >> $GITHUB_STEP_SUMMARY
+        run: cat summary.md >> $GITHUB_STEP_SUMMARY
 ```
 
 #### Using GitHub app
@@ -289,7 +289,7 @@ jobs:
           GROUP_DEPENDENCIES: True
 
       - name: Post evergreen job summary
-        run: cat summmary.md >> $GITHUB_STEP_SUMMARY
+        run: cat summary.md >> $GITHUB_STEP_SUMMARY
 ```
 
 ## Local usage without Docker

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ jobs:
           TITLE: "Add dependabot configuration"
           BODY: "Please add this dependabot configuration so that we can keep the dependencies in this repo up to date and secure. for help, contact XXX"
           CREATED_AFTER_DATE: ${{ env.one_week_ago }}
-      
+
       - name: Post evergreen job summary
         run: cat summary.md >> $GITHUB_STEP_SUMMARY
 ```

--- a/README.md
+++ b/README.md
@@ -249,6 +249,9 @@ jobs:
           TITLE: "Add dependabot configuration"
           BODY: "Please add this dependabot configuration so that we can keep the dependencies in this repo up to date and secure. for help, contact XXX"
           CREATED_AFTER_DATE: ${{ env.one_week_ago }}
+      
+      - name: Post evergreen job summary
+        run: cat summmary.md >> GITHUB_STEP_SUMMARY
 ```
 
 #### Using GitHub app
@@ -281,6 +284,9 @@ jobs:
           ORGANIZATION: your_organization
           UPDATE_EXISTING: True
           GROUP_DEPENDENCIES: True
+
+      - name: Post evergreen job summary
+        run: cat summmary.md >> GITHUB_STEP_SUMMARY
 ```
 
 ## Local usage without Docker

--- a/action.yml
+++ b/action.yml
@@ -4,9 +4,7 @@ author: "github"
 description: "A GitHub Action to request dependabot enablement on eligible repositories in an organization."
 runs:
   using: "docker"
-  image: Dockerfile
-  #image: "docker://ghcr.io/github/evergreen:v1"
-  options: --volume ${{ env.GITHUB_STEP_SUMMARY }}:/github/summary
+  image: "docker://ghcr.io/github/evergreen:v1"
 branding:
   icon: "file-plus"
   color: "green"

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,9 @@ author: "github"
 description: "A GitHub Action to request dependabot enablement on eligible repositories in an organization."
 runs:
   using: "docker"
-  image: "docker://ghcr.io/github/evergreen:v1"
+  image: Dockerfile
+  #image: "docker://ghcr.io/github/evergreen:v1"
+  options: --volume ${{ env.GITHUB_STEP_SUMMARY }}:/github/summary
 branding:
   icon: "file-plus"
   color: "green"

--- a/evergreen.py
+++ b/evergreen.py
@@ -540,7 +540,7 @@ def link_item_to_project(ghe, token, project_id, item_id):
         return None
 
 
-def append_to_github_summary(content, summary_file="/github/workspace/summary.md"):
+def append_to_github_summary(content, summary_file="summary.md"):
     """
     Append content to the GitHub step summary file
     """

--- a/evergreen.py
+++ b/evergreen.py
@@ -537,13 +537,13 @@ def link_item_to_project(ghe, token, project_id, item_id):
         print(f"Request failed: {e}")
         return None
 
-def append_to_github_summary(content, summary_file='/github/workspace/summary.md'):
+def append_to_github_summary(content, summary_file="/github/workspace/summary.md"):
     """
     Append content to the GitHub step summary file
     """
     if summary_file:
-        with open(summary_file, 'a') as f:
-            f.write(content + '\n')
+        with open(summary_file, "a") as f:
+            f.write(content + "\n")
 
 
 if __name__ == "__main__":

--- a/evergreen.py
+++ b/evergreen.py
@@ -271,9 +271,6 @@ def main():  # pragma: no cover
     # Append the summary content to the GitHub step summary file
     append_to_github_summary(summary_content)
 
-    # Set the summary content as an output
-    set_output("summary", summary_content)
-
     print(f"Done. {str(count_eligible)} repositories were eligible.")
 
 
@@ -540,15 +537,13 @@ def link_item_to_project(ghe, token, project_id, item_id):
         print(f"Request failed: {e}")
         return None
 
-def append_to_github_summary(content):
+def append_to_github_summary(content, summary_file='/github/workspace/summary.md'):
     """
     Append content to the GitHub step summary file
     """
-    summary_file = os.getenv('GITHUB_STEP_SUMMARY')
     if summary_file:
         with open(summary_file, 'a') as f:
             f.write(content + '\n')
-
 
 
 if __name__ == "__main__":

--- a/evergreen.py
+++ b/evergreen.py
@@ -537,6 +537,7 @@ def link_item_to_project(ghe, token, project_id, item_id):
         print(f"Request failed: {e}")
         return None
 
+
 def append_to_github_summary(content, summary_file="/github/workspace/summary.md"):
     """
     Append content to the GitHub step summary file

--- a/evergreen.py
+++ b/evergreen.py
@@ -543,7 +543,7 @@ def append_to_github_summary(content, summary_file="/github/workspace/summary.md
     Append content to the GitHub step summary file
     """
     if summary_file:
-        with open(summary_file, "a") as f:
+        with open(summary_file, "a", encoding="utf-8") as f:
             f.write(content + "\n")
 
 

--- a/evergreen.py
+++ b/evergreen.py
@@ -95,7 +95,11 @@ def main():  # pragma: no cover
         summary_content += f"- **Batch Size:** {batch_size}\n"
 
     # Add the updated repositories table header
-    summary_content += "\n\n## 📋 Updated Repositories\n\n| Repository | 🔒 Security Updates Enabled | 🔄 Follow Up Type | 🔗 Link |\n| --- | --- | --- | --- |\n"
+    summary_content += (
+        "\n\n## 📋 Updated Repositories\n\n"
+        "| Repository | 🔒 Security Updates Enabled | 🔄 Follow Up Type | 🔗 Link |\n"
+        "| --- | --- | --- | --- |\n"
+    )
 
     # Iterate through the repositories and open an issue/PR if dependabot is not enabled
     count_eligible = 0

--- a/evergreen.py
+++ b/evergreen.py
@@ -212,12 +212,10 @@ def main():  # pragma: no cover
             continue
 
         # Get dependabot security updates enabled if possible
-        security_updates_enabled = False
         if enable_security_updates:
-            security_updates_enabled = is_dependabot_security_updates_enabled(
+            if not is_dependabot_security_updates_enabled(
                 ghe, repo.owner, repo.name, token
-            )
-            if security_updates_enabled:
+            ):
                 enable_dependabot_security_updates(ghe, repo.owner, repo.name, token)
 
         link = ""
@@ -265,7 +263,7 @@ def main():  # pragma: no cover
                     print("\tFailed to create pull request. Check write permissions.")
                     continue
         # Append the repository to the summary content
-        summary_content += f"| {repo.full_name} | {'✅' if security_updates_enabled else '❌'} | {follow_up_type} | [Link]({link}) |\n"
+        summary_content += f"| {repo.full_name} | {'✅' if enable_security_updates else '❌'} | {follow_up_type} | [Link]({link}) |\n"
 
     print(f"Done. {str(count_eligible)} repositories were eligible.")
     # Append the summary content to the GitHub step summary file

--- a/evergreen.py
+++ b/evergreen.py
@@ -79,6 +79,24 @@ def main():  # pragma: no cover
         organization, team_name, repository_list, github_connection
     )
 
+    # Setting up the action summary content
+    summary_content = f"""
+    ## 🚀 Job Summary
+    - **Organization:** {organization}
+    - **Follow Up Type:** {follow_up_type}
+    - **Dry Run:** {dry_run}
+    - **Enable Security Updates:** {enable_security_updates}
+    """
+    # Add optional parameters to the summary
+    if project_id:
+        project_link = f"https://github.com/orgs/{organization}/projects/{project_id}"
+        summary_content += f"- **Project ID:** [{project_id}]({project_link})\n"
+    if batch_size:
+        summary_content += f"- **Batch Size:** {batch_size}\n"
+
+    # Add the updated repositories table header
+    summary_content += "\n\n## 📋 Updated Repositories\n\n| Repository | 🔒 Security Updates Enabled | 🔄 Follow Up Type | 🔗 Link |\n| --- | --- | --- | --- |\n"
+
     # Iterate through the repositories and open an issue/PR if dependabot is not enabled
     count_eligible = 0
     for repo in repos:
@@ -194,18 +212,22 @@ def main():  # pragma: no cover
             continue
 
         # Get dependabot security updates enabled if possible
+        security_updates_enabled = False
         if enable_security_updates:
-            if not is_dependabot_security_updates_enabled(
+            security_updates_enabled = is_dependabot_security_updates_enabled(
                 ghe, repo.owner, repo.name, token
-            ):
+            )
+            if security_updates_enabled:
                 enable_dependabot_security_updates(ghe, repo.owner, repo.name, token)
 
+        link = ""
         if follow_up_type == "issue":
             skip = check_pending_issues_for_duplicates(title, repo)
             if not skip:
                 count_eligible += 1
                 body_issue = f"{body}\n\n```yaml\n# {dependabot_filename_to_use} \n{dependabot_file}\n```"
                 issue = repo.create_issue(title, body_issue)
+                link = issue.html_url
                 print(f"\tCreated issue {issue.html_url}")
                 if project_id:
                     issue_id = get_global_issue_id(
@@ -230,6 +252,7 @@ def main():  # pragma: no cover
                         dependabot_filename_to_use,
                         existing_config,
                     )
+                    link = pull.html_url
                     print(f"\tCreated pull request {pull.html_url}")
                     if project_id:
                         pr_id = get_global_pr_id(
@@ -241,6 +264,15 @@ def main():  # pragma: no cover
                 except github3.exceptions.NotFoundError:
                     print("\tFailed to create pull request. Check write permissions.")
                     continue
+        # Append the repository to the summary content
+        summary_content += f"| {repo.full_name} | {'✅' if security_updates_enabled else '❌'} | {follow_up_type} | [Link]({link}) |\n"
+
+    print(f"Done. {str(count_eligible)} repositories were eligible.")
+    # Append the summary content to the GitHub step summary file
+    append_to_github_summary(summary_content)
+
+    # Set the summary content as an output
+    set_output("summary", summary_content)
 
     print(f"Done. {str(count_eligible)} repositories were eligible.")
 
@@ -507,6 +539,16 @@ def link_item_to_project(ghe, token, project_id, item_id):
     except requests.exceptions.RequestException as e:
         print(f"Request failed: {e}")
         return None
+
+def append_to_github_summary(content):
+    """
+    Append content to the GitHub step summary file
+    """
+    summary_file = os.getenv('GITHUB_STEP_SUMMARY')
+    if summary_file:
+        with open(summary_file, 'a') as f:
+            f.write(content + '\n')
+
 
 
 if __name__ == "__main__":

--- a/test_evergreen.py
+++ b/test_evergreen.py
@@ -750,7 +750,7 @@ class TestAppendToGithubSummary(unittest.TestCase):
 
         append_to_github_summary(content, summary_file)
 
-        mock_file.assert_called_once_with(summary_file, "a")
+        mock_file.assert_called_once_with(summary_file, "a", encoding="utf-8")
         mock_file().write.assert_called_once_with(content + "\n")
 
     @patch("builtins.open", new_callable=unittest.mock.mock_open)
@@ -770,7 +770,7 @@ class TestAppendToGithubSummary(unittest.TestCase):
 
         append_to_github_summary(content)
 
-        mock_file.assert_called_once_with("/github/workspace/summary.md", "a")
+        mock_file.assert_called_once_with("/github/workspace/summary.md", "a", encoding="utf-8")
         mock_file().write.assert_called_once_with(content + "\n")
 
 

--- a/test_evergreen.py
+++ b/test_evergreen.py
@@ -771,7 +771,7 @@ class TestAppendToGithubSummary(unittest.TestCase):
         append_to_github_summary(content)
 
         mock_file.assert_called_once_with("/github/workspace/summary.md", "a")
-        mock_file().write.assert_called_once_with(content + '\n')
+        mock_file().write.assert_called_once_with(content + "\n")
 
 
 if __name__ == "__main__":

--- a/test_evergreen.py
+++ b/test_evergreen.py
@@ -770,9 +770,7 @@ class TestAppendToGithubSummary(unittest.TestCase):
 
         append_to_github_summary(content)
 
-        mock_file.assert_called_once_with(
-            "summary.md", "a", encoding="utf-8"
-        )
+        mock_file.assert_called_once_with("summary.md", "a", encoding="utf-8")
         mock_file().write.assert_called_once_with(content + "\n")
 
 

--- a/test_evergreen.py
+++ b/test_evergreen.py
@@ -746,7 +746,7 @@ class TestAppendToGithubSummary(unittest.TestCase):
     def test_append_to_github_summary_with_file(self, mock_file):
         """Test that content is appended to the specified summary file."""
         content = "Test summary content"
-        summary_file = "/path/to/summary.md"
+        summary_file = "summary.md"
 
         append_to_github_summary(content, summary_file)
 
@@ -771,7 +771,7 @@ class TestAppendToGithubSummary(unittest.TestCase):
         append_to_github_summary(content)
 
         mock_file.assert_called_once_with(
-            "/github/workspace/summary.md", "a", encoding="utf-8"
+            "summary.md", "a", encoding="utf-8"
         )
         mock_file().write.assert_called_once_with(content + "\n")
 

--- a/test_evergreen.py
+++ b/test_evergreen.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 import github3
 import requests
 from evergreen import (
+    append_to_github_summary,
     check_existing_config,
     check_pending_issues_for_duplicates,
     check_pending_pulls_for_duplicates,
@@ -19,7 +20,6 @@ from evergreen import (
     is_dependabot_security_updates_enabled,
     is_repo_created_date_before,
     link_item_to_project,
-    append_to_github_summary,
 )
 
 

--- a/test_evergreen.py
+++ b/test_evergreen.py
@@ -738,6 +738,7 @@ class TestCheckExistingConfig(unittest.TestCase):
 
         self.assertIsNone(result)
 
+
 class TestAppendToGithubSummary(unittest.TestCase):
     """Test the append_to_github_summary function in evergreen.py"""
 
@@ -749,8 +750,8 @@ class TestAppendToGithubSummary(unittest.TestCase):
 
         append_to_github_summary(content, summary_file)
 
-        mock_file.assert_called_once_with(summary_file, 'a')
-        mock_file().write.assert_called_once_with(content + '\n')
+        mock_file.assert_called_once_with(summary_file, "a")
+        mock_file().write.assert_called_once_with(content + "\n")
 
     @patch("builtins.open", new_callable=unittest.mock.mock_open)
     def test_append_to_github_summary_without_summary_file(self, mock_file):
@@ -769,7 +770,7 @@ class TestAppendToGithubSummary(unittest.TestCase):
 
         append_to_github_summary(content)
 
-        mock_file.assert_called_once_with('/github/workspace/summary.md', 'a')
+        mock_file.assert_called_once_with("/github/workspace/summary.md", "a")
         mock_file().write.assert_called_once_with(content + '\n')
 
 

--- a/test_evergreen.py
+++ b/test_evergreen.py
@@ -770,7 +770,9 @@ class TestAppendToGithubSummary(unittest.TestCase):
 
         append_to_github_summary(content)
 
-        mock_file.assert_called_once_with("/github/workspace/summary.md", "a", encoding="utf-8")
+        mock_file.assert_called_once_with(
+            "/github/workspace/summary.md", "a", encoding="utf-8"
+        )
         mock_file().write.assert_called_once_with(content + "\n")
 
 

--- a/test_evergreen.py
+++ b/test_evergreen.py
@@ -19,6 +19,7 @@ from evergreen import (
     is_dependabot_security_updates_enabled,
     is_repo_created_date_before,
     link_item_to_project,
+    append_to_github_summary,
 )
 
 
@@ -736,6 +737,40 @@ class TestCheckExistingConfig(unittest.TestCase):
         result = check_existing_config(mock_repo, "dependabot.yml")
 
         self.assertIsNone(result)
+
+class TestAppendToGithubSummary(unittest.TestCase):
+    """Test the append_to_github_summary function in evergreen.py"""
+
+    @patch("builtins.open", new_callable=unittest.mock.mock_open)
+    def test_append_to_github_summary_with_file(self, mock_file):
+        """Test that content is appended to the specified summary file."""
+        content = "Test summary content"
+        summary_file = "/path/to/summary.md"
+
+        append_to_github_summary(content, summary_file)
+
+        mock_file.assert_called_once_with(summary_file, 'a')
+        mock_file().write.assert_called_once_with(content + '\n')
+
+    @patch("builtins.open", new_callable=unittest.mock.mock_open)
+    def test_append_to_github_summary_without_summary_file(self, mock_file):
+        """Test that content is not written when summary_file is None or empty."""
+        content = "Test summary content"
+        summary_file = ""
+
+        append_to_github_summary(content, summary_file)
+
+        mock_file.assert_not_called()
+
+    @patch("builtins.open", new_callable=unittest.mock.mock_open)
+    def test_append_to_github_summary_with_default_file(self, mock_file):
+        """Test that content is appended to the default summary file when summary_file is not provided."""
+        content = "Test summary content"
+
+        append_to_github_summary(content)
+
+        mock_file.assert_called_once_with('/github/workspace/summary.md', 'a')
+        mock_file().write.assert_called_once_with(content + '\n')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request introduces a feature to generate and append a job summary to a GitHub step summary file. The changes span across documentation, the main script, and the test suite. The most important changes include the addition of job summary content setup, appending the summary to a file, and corresponding tests.

### Job Summary Feature:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R252-R254): Added steps to post the evergreen job summary in the GitHub Actions workflow. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R252-R254) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R287-R289)

### Main Script Enhancements:

* [`evergreen.py`](diffhunk://#diff-b2e641407994f0e45d80e45129e5d0388cc50cdfe231fe65d25603aa7c742293R82-R99): Introduced the setup of job summary content, including organization details, optional parameters, and a table of updated repositories. [[1]](diffhunk://#diff-b2e641407994f0e45d80e45129e5d0388cc50cdfe231fe65d25603aa7c742293R82-R99) [[2]](diffhunk://#diff-b2e641407994f0e45d80e45129e5d0388cc50cdfe231fe65d25603aa7c742293R215-R230)
* [`evergreen.py`](diffhunk://#diff-b2e641407994f0e45d80e45129e5d0388cc50cdfe231fe65d25603aa7c742293R255): Appended the repository information to the summary content and added the function to write the summary content to a file. [[1]](diffhunk://#diff-b2e641407994f0e45d80e45129e5d0388cc50cdfe231fe65d25603aa7c742293R255) [[2]](diffhunk://#diff-b2e641407994f0e45d80e45129e5d0388cc50cdfe231fe65d25603aa7c742293R267-R272) [[3]](diffhunk://#diff-b2e641407994f0e45d80e45129e5d0388cc50cdfe231fe65d25603aa7c742293R540-R547)

### Test Suite Additions:

* [`test_evergreen.py`](diffhunk://#diff-3df30460a786eda5c5b92438e68248816b549de8f0e51128ba54af948f9e20d0R22): Added tests for the `append_to_github_summary` function to ensure content is correctly appended to the specified summary file. [[1]](diffhunk://#diff-3df30460a786eda5c5b92438e68248816b549de8f0e51128ba54af948f9e20d0R22) [[2]](diffhunk://#diff-3df30460a786eda5c5b92438e68248816b549de8f0e51128ba54af948f9e20d0R741-R774)